### PR TITLE
Adding CoreDisplaySettings.cs to included files

### DIFF
--- a/Web/mojoPortal.Web.csproj
+++ b/Web/mojoPortal.Web.csproj
@@ -1488,6 +1488,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>PageManagerResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="App_MasterPages\CoreDisplaySettings.cs" />
     <Compile Include="App_MasterPages\LayoutDisplaySettings.cs" />
     <Compile Include="App_Start\MappingProfile.cs" />
     <Compile Include="BingSearch.aspx.cs">


### PR DESCRIPTION
The CoreDisplaySettings.cs file was not in the project file.   Will not compile unless included in project.