### PR TITLE
Web: Fixed issue when the phSiteFooter placeholder wasn't in the skin

### DIFF
--- a/Web/Components/mojoBasePage.cs
+++ b/Web/Components/mojoBasePage.cs
@@ -1,3 +1,10 @@
+using log4net;
+using mojoPortal.Business;
+using mojoPortal.Business.WebHelpers;
+using mojoPortal.Web.Framework;
+using mojoPortal.Web.Models;
+using mojoPortal.Web.UI;
+using Resources;
 using System;
 using System.Globalization;
 using System.IO;
@@ -7,12 +14,6 @@ using System.Web.Security;
 using System.Web.UI;
 using System.Web.UI.HtmlControls;
 using System.Web.UI.WebControls;
-using log4net;
-using mojoPortal.Business;
-using mojoPortal.Business.WebHelpers;
-using mojoPortal.Web.Framework;
-using mojoPortal.Web.UI;
-using Resources;
 
 namespace mojoPortal.Web;
 
@@ -84,33 +85,15 @@ public class mojoBasePage : Page
 
 	public void EnsureDefaultModal()
 	{
-		ScriptManager.RegisterStartupScript(this, typeof(Page), "mojoModalScript", $"\r\n<script data-loader=\"mojoBasePage\" src=\"{Global.SkinConfig.ModalScriptPath.ToLinkBuilder(useRelativePath: false)}\"></script>", false);
-
-		if (Master.FindControl("phSiteFooter") is Control phSiteFooter)
+		if (
+			Master.FindControl("phSiteFooter") is Control siteFooter &&
+			siteFooter.FindControlRecursive("mojoModalTemplate") is Literal modalTemplate &&
+			modalTemplate.Visible == false
+		)
 		{
-			injectModalTemplate(phSiteFooter);
-		}
-		else if (Master.FindControl("Body") is Control layoutBody)
-		{
-			injectModalTemplate(layoutBody);
-		}
+			ScriptManager.RegisterStartupScript(this, typeof(Page), "mojoModalScript", $"\r\n<script data-loader=\"mojoBasePage\" src=\"{Global.SkinConfig.ModalScriptPath.ToLinkBuilder(useRelativePath: false)}\"></script>", false);
 
-		void injectModalTemplate(Control control)
-		{
-			if (control.FindControlRecursive("mojoModalTemplate") is null)
-			{
-				FileInfo modalFile = new(Server.MapPath(Global.SkinConfig.ModalTemplatePath));
-				if (modalFile.Exists)
-				{
-					var content = File.ReadAllText(modalFile.FullName);
-
-					control.Controls.AddAt(control.Controls.Count, new Literal
-					{
-						Text = content,
-						ID = "mojoModalTemplate"
-					});
-				}
-			}
+			modalTemplate.Visible = true;
 		}
 	}
 
@@ -1601,6 +1584,8 @@ public class mojoBasePage : Page
 		}
 
 		SetupAdminLinks();
+		SetupSiteFooterControl();
+		SetupDefaultModal();
 
 		// older skins may not have it included in layout.master so we load it here
 		if (ScriptConfig is not null && !scriptLoaderFoundInMaster)
@@ -1650,6 +1635,48 @@ public class mojoBasePage : Page
 			}
 		}
 	}
+
+
+	private void SetupSiteFooterControl()
+	{
+		if (
+			Master.FindControl("phSiteFooter") is not PlaceHolder &&
+			Master.FindControl("Body") is Control layoutBody
+		)
+		{
+			var siteFooter = new PlaceHolder
+			{
+				ID = "phSiteFooter"
+			};
+
+			layoutBody.Controls.Add(siteFooter);
+		}
+	}
+
+
+	private void SetupDefaultModal()
+	{
+		if (
+			Master.FindControl("phSiteFooter") is Control siteFooter &&
+			siteFooter.FindControlRecursive("mojoModalTemplate") is null
+		)
+		{
+			var modalFile = new FileInfo(Server.MapPath(Global.SkinConfig.ModalTemplatePath));
+
+			if (modalFile.Exists)
+			{
+				var content = File.ReadAllText(modalFile.FullName);
+
+				siteFooter.Controls.AddAt(siteFooter.Controls.Count, new Literal
+				{
+					Text = content,
+					ID = "mojoModalTemplate",
+					Visible = false
+				});
+			}
+		}
+	}
+
 
 	protected void HideViewSelector()
 	{

--- a/Web/Controls/FileManagerLink.cs
+++ b/Web/Controls/FileManagerLink.cs
@@ -1,260 +1,210 @@
-﻿using System;
+﻿using mojoPortal.Business.WebHelpers;
+using Resources;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
-using mojoPortal.Business.WebHelpers;
-using Resources;
-using System.Collections.Generic;
-using System.Linq;
 
-namespace mojoPortal.Web.UI
+namespace mojoPortal.Web.UI;
+
+/// <summary>
+/// A convenience link for the File Manager. The link renders only for those in roles that can use it
+/// </summary>
+public class FileManagerLink : HyperLink
 {
-	/// <summary>
-	/// A convenience link for the File Manager. The link renders only for those in roles that can use it
-	/// </summary>
-	public class FileManagerLink : HyperLink
+	private mojoBasePage basePage = null;
+
+	public bool RenderAsListItem { get; set; } = false;
+	public string ListItemCss { get; set; } = string.Empty;
+	public string ListItemID { get; set; } = string.Empty;
+	public bool OpenInModal { get; set; } = true;
+	public string ModalHookType { get; set; } = "CssClass";
+	public string ModalHookValue { get; set; } = "cblink";
+	public string QueryString { get; set; } = string.Empty;
+	public string LiteralExtraTopContent { get; set; } = string.Empty;
+	public string LiteralExtraBottomContent { get; set; } = string.Empty;
+	public string LinkImageUrl { get; set; } = string.Empty;
+
+
+	public bool ShouldRender()
 	{
-		private mojoBasePage basePage = null;
-
-		private bool renderAsListItem = false;
-		public bool RenderAsListItem
+		if (basePage == null)
 		{
-			get { return renderAsListItem; }
-			set { renderAsListItem = value; }
-		}
-
-		private string listItemCSS = string.Empty;
-		public string ListItemCss
-		{
-			get { return listItemCSS; }
-			set { listItemCSS = value; }
-		}
-
-		private string listItemID = string.Empty;
-		public string ListItemID
-		{
-			get { return listItemID; }
-			set { listItemID = value; }
-		}
-
-		private bool openInModal = true;
-		public bool OpenInModal
-		{
-			get { return openInModal; }
-			set { openInModal = value; }
-		}
-
-		private string modalHookType = "CssClass"; // There's two types, "CssClass" and "Attributes". The value of Attributes should be key:value pairs that are comma seperated
-		public string ModalHookType
-		{
-			get { return modalHookType; }
-			set { modalHookType = value; }
-		}
-
-		private string modalHookValue = "cblink";
-		public string ModalHookValue
-		{
-			get { return modalHookValue; }
-			set { modalHookValue = value; }
-		}
-
-		private string queryString = string.Empty;
-		public string QueryString
-		{
-			get { return queryString; }
-			set { queryString = value; }
-		}
-
-		private string literalExtraTopContent = string.Empty;
-		public string LiteralExtraTopContent
-		{
-			get { return literalExtraTopContent; }
-			set { literalExtraTopContent = value; }
-		}
-
-		private string literalExtraBottomContent = string.Empty;
-		public string LiteralExtraBottomContent
-		{
-			get { return literalExtraBottomContent; }
-			set { literalExtraBottomContent = value; }
-		}
-
-		private string linkImageUrl = string.Empty;
-		public string LinkImageUrl
-		{
-			get { return linkImageUrl; }
-			set { linkImageUrl = value; }
-		}
-
-		public bool ShouldRender()
-		{
-			if (basePage == null) {
-				return false;
-			}
-
-			if (!Page.Request.IsAuthenticated) {
-				return false;
-			}
-
-			if (!WebConfigSettings.ShowFileManagerLink) {
-				return false;
-			}
-
-			if (WebConfigSettings.DisableFileManager) {
-				return false;
-			}
-
-			if (basePage.SiteInfo == null) {
-				return false;
-			}
-
-			if ((!CacheHelper.GetCurrentSiteSettings().IsServerAdminSite) && (!AppConfig.MultiTenancy.AllowFileManager))
-			{
-				return false;
-			}
-
-			if (SiteUtils.UserIsSiteEditor() || WebUser.IsAdminOrContentAdmin) {
-				return true;
-			}
-
-			// Only roles that can delete can use File Manager
-			if (!WebUser.IsInRoles(basePage.SiteInfo.RolesThatCanDeleteFilesInEditor)) {
-				return false;
-			}
-
-			if (WebUser.IsInRoles(basePage.SiteInfo.UserFilesBrowseAndUploadRoles)
-				|| WebUser.IsInRoles(basePage.SiteInfo.GeneralBrowseAndUploadRoles)
-				|| WebUser.IsInRoles(basePage.SiteInfo.GeneralBrowseRoles))
-			{
-				return true;
-			}
-
 			return false;
 		}
 
-
-		protected override void OnLoad(EventArgs e)
+		if (!Page.Request.IsAuthenticated)
 		{
-			base.OnLoad(e);
+			return false;
+		}
 
-			if (HttpContext.Current == null) {
-				return;
-			}
+		if (!WebConfigSettings.ShowFileManagerLink)
+		{
+			return false;
+		}
 
-			EnableViewState = false;
-			basePage = Page as mojoBasePage;
-			Visible = ShouldRender();
+		if (WebConfigSettings.DisableFileManager)
+		{
+			return false;
+		}
 
-			if (!Visible) {
-				return;
-			}
+		if (basePage.SiteInfo == null)
+		{
+			return false;
+		}
 
-			if (basePage == null) {
-				return;
-			}
+		if ((!CacheHelper.GetCurrentSiteSettings().IsServerAdminSite) && (!AppConfig.MultiTenancy.AllowFileManager))
+		{
+			return false;
+		}
+
+		if (SiteUtils.UserIsSiteEditor() || WebUser.IsAdminOrContentAdmin)
+		{
+			return true;
+		}
+
+		// Only roles that can delete can use File Manager
+		if (!WebUser.IsInRoles(basePage.SiteInfo.RolesThatCanDeleteFilesInEditor))
+		{
+			return false;
+		}
+
+		if (WebUser.IsInRoles(basePage.SiteInfo.UserFilesBrowseAndUploadRoles)
+			|| WebUser.IsInRoles(basePage.SiteInfo.GeneralBrowseAndUploadRoles)
+			|| WebUser.IsInRoles(basePage.SiteInfo.GeneralBrowseRoles))
+		{
+			return true;
+		}
+
+		return false;
+	}
 
 
-			if (string.IsNullOrWhiteSpace(Global.SkinConfig.ModalTemplatePath) || string.IsNullOrWhiteSpace(Global.SkinConfig.ModalScriptPath))
+	protected override void OnLoad(EventArgs e)
+	{
+		base.OnLoad(e);
+
+		if (HttpContext.Current == null)
+		{
+			return;
+		}
+
+		EnableViewState = false;
+		basePage = Page as mojoBasePage;
+		Visible = ShouldRender();
+
+		if (!Visible)
+		{
+			return;
+		}
+
+		if (basePage == null)
+		{
+			return;
+		}
+
+		if (string.IsNullOrWhiteSpace(Global.SkinConfig.ModalTemplatePath) || string.IsNullOrWhiteSpace(Global.SkinConfig.ModalScriptPath))
+		{
+			basePage.ScriptConfig.IncludeColorBox = true;
+		}
+		else
+		{
+			basePage.EnsureDefaultModal();
+		}
+
+		if (OpenInModal && ModalHookType == "CssClass")
+		{
+			CssClass = $"adminlink filemanlink {CssClass} {ModalHookValue}";
+		}
+		else
+		{
+			CssClass = $"adminlink filemanlink {CssClass}";
+		}
+
+		if (OpenInModal && (ModalHookType == "Attributes"))
+		{
+			Dictionary<string, string> keyValuePairs = ModalHookValue.Split(',')
+				.Select(v => v.Split(':'))
+				.ToDictionary(pair => pair[0], pair => pair[1]);
+
+			foreach (KeyValuePair<string, string> item in keyValuePairs)
 			{
-				basePage.ScriptConfig.IncludeColorBox = true;
-			}
-			else
-			{
-				basePage.EnsureDefaultModal();
-			}
-
-			if (openInModal && modalHookType == "CssClass")
-			{
-				CssClass = $"adminlink filemanlink {CssClass} {modalHookValue}";
-			}
-			else
-			{
-				CssClass = $"adminlink filemanlink {CssClass}";
-			}
-			
-			if (openInModal && (modalHookType == "Attributes"))
-			{
-				Dictionary<string, string> keyValuePairs = modalHookValue.Split(',')
-					.Select(v => v.Split(':'))
-					.ToDictionary(pair => pair[0], pair => pair[1]);
-
-				foreach (KeyValuePair<string, string> item in keyValuePairs)
-				{
-					Attributes.Add(item.Key, item.Value);
-				}
-			}
-
-			Controls.Add(new Literal
-			{
-				Text = literalExtraTopContent
-			});
-
-			Controls.Add(new Literal
-			{
-				Text = Resource.AdminMenuFileManagerLink
-			});
-
-			Controls.Add(new Literal
-			{
-				Text = literalExtraBottomContent
-			});
-			
-			ToolTip = Resource.AdminMenuFileManagerLink;
-
-			if (SiteUtils.SslIsAvailable())
-			{
-				NavigateUrl = $"{basePage.SiteRoot}/FileManager{queryString}";
-			}
-			else
-			{
-				NavigateUrl = $"{basePage.RelativeSiteRoot}/FileManager{queryString}";
-			}
-
-			if (!string.IsNullOrWhiteSpace(linkImageUrl) && !openInModal)
-			{
-				if (linkImageUrl.StartsWith("~/"))
-				{
-					ImageUrl = Page.ResolveUrl(linkImageUrl);
-				}
-				else
-				{
-					ImageUrl = SiteUtils.DetermineSkinBaseUrl(page: Page) + linkImageUrl.TrimStart('/');
-				}
+				Attributes.Add(item.Key, item.Value);
 			}
 		}
 
-		protected override void Render(HtmlTextWriter writer)
+		Controls.Add(new Literal
 		{
-			if (HttpContext.Current == null)
+			Text = LiteralExtraTopContent
+		});
+
+		Controls.Add(new Literal
+		{
+			Text = Resource.AdminMenuFileManagerLink
+		});
+
+		Controls.Add(new Literal
+		{
+			Text = LiteralExtraBottomContent
+		});
+
+		ToolTip = Resource.AdminMenuFileManagerLink;
+
+		if (SiteUtils.SslIsAvailable())
+		{
+			NavigateUrl = $"{basePage.SiteRoot}/FileManager{QueryString}";
+		}
+		else
+		{
+			NavigateUrl = $"{basePage.RelativeSiteRoot}/FileManager{QueryString}";
+		}
+
+		if (!string.IsNullOrWhiteSpace(LinkImageUrl) && !OpenInModal)
+		{
+			if (LinkImageUrl.StartsWith("~/"))
 			{
-				writer.Write("[" + ID + "]");
-				return;
+				ImageUrl = Page.ResolveUrl(LinkImageUrl);
+			}
+			else
+			{
+				ImageUrl = SiteUtils.DetermineSkinBaseUrl(page: Page) + LinkImageUrl.TrimStart('/');
+			}
+		}
+	}
+
+	protected override void Render(HtmlTextWriter writer)
+	{
+		if (HttpContext.Current == null)
+		{
+			writer.Write("[" + ID + "]");
+			return;
+		}
+
+		if (RenderAsListItem)
+		{
+			string liClass = string.Empty;
+			string liID = string.Empty;
+
+			if (ListItemID.Length > 0)
+			{
+				liID = " id=\"" + ListItemID + "\"";
 			}
 
-			if (renderAsListItem)
+			if (ListItemCss.Length > 0)
 			{
-				string liClass = string.Empty;
-				string liID = string.Empty;
-
-				if (listItemID.Length > 0)
-				{
-					liID = " id=\"" + listItemID + "\"";
-				}
-
-				if (listItemCSS.Length > 0)
-				{
-					liClass = " class=\"" + listItemCSS + "\"";
-				}
-
-				writer.Write("<li" + liID + liClass + ">");
+				liClass = " class=\"" + ListItemCss + "\"";
 			}
 
-			base.Render(writer);
+			writer.Write("<li" + liID + liClass + ">");
+		}
 
-			if (renderAsListItem)
-			{
-				writer.Write("</li>");
-			}
+		base.Render(writer);
+
+		if (RenderAsListItem)
+		{
+			writer.Write("</li>");
 		}
 	}
 }


### PR DESCRIPTION
The site would bomb out if the placeholder wasn't in the skin, it is no longer required.