### PR TITLE
Fixed issue where blog comments would never submit

### DIFF
--- a/Web/Controls/CommentSystems/Controls/CommentEditor.ascx.cs
+++ b/Web/Controls/CommentSystems/Controls/CommentEditor.ascx.cs
@@ -356,9 +356,18 @@ namespace mojoPortal.Web.UI
 
 		private bool IsValidComment()
 		{
+			edComment.Text = edComment.Text.Trim();
+			txtName.Text = txtName.Text.Trim();
+			txtEmail.Text = txtEmail.Text.Trim();
+			txtCommentTitle.Text = txtCommentTitle.Text.Trim();
 
-			if (edComment.Text.Length == 0) { return false; }
-			if (edComment.Text == "<p>&#160;</p>") { return false; } //some editors add this when its empty
+			if (
+				string.IsNullOrWhiteSpace(edComment.Text) ||
+				edComment.Text == "<p>&#160;</p>"
+			)
+			{
+				return false;
+			}
 
 			bool result = true;
 
@@ -375,7 +384,6 @@ namespace mojoPortal.Web.UI
 			{
 				//manipulation can make the Challenge null on recaptcha
 			}
-
 
 			if (siteSettings.BadWordCheckingEnabled && (CheckKeywordBlacklist || siteSettings.BadWordCheckingEnforced))
 			{
@@ -427,9 +435,10 @@ namespace mojoPortal.Web.UI
 				return false;
 			}
 
-			if (SecurityHelper.IsPossibleXss(txtName.Text) 
-				|| SecurityHelper.IsPossibleXss(txtCommentTitle.Text)
-				)
+			if (
+				SecurityHelper.IsPossibleXss(txtName.Text) ||
+				SecurityHelper.IsPossibleXss(txtCommentTitle.Text)
+			)
 			{
 				return false;
 			}

--- a/mojoPortal.Web.Framework/SecurityHelper.cs
+++ b/mojoPortal.Web.Framework/SecurityHelper.cs
@@ -249,6 +249,8 @@ public static class SecurityHelper
 	/// <returns>True if string is possibly XSS attemp. False if string is clean.</returns>
 	public static bool IsPossibleXss(string text)
 	{
+		text = text.Trim();
+
 		if (text.RemoveMarkup() != text)
 		{
 			return true;


### PR DESCRIPTION
The issue is there's a SecurityHelper.IsPossibleXss method that does a string comparison after removing markup from the string. The new method to remove markup from strings also trims the string, and the posting a comment without a title would submit the title as "re: ", and the returned value from the RemoveMarkup method is "re:' (no space at the end).

Trimmed all fields for the comments, and also trimmed input to the IsPossibleXss method as well.