### PR TITLE
Fix HTML class rendering for module title element

### DIFF
--- a/Plugins/SuperFlexi/SuperFlexiUI/Views/SuperFlexi/_ModuleTitle.cshtml
+++ b/Plugins/SuperFlexi/SuperFlexiUI/Views/SuperFlexi/_ModuleTitle.cshtml
@@ -6,7 +6,7 @@
 @if (Model.Module.ShowTitle)
 {
 
-	@Html.Raw("<" + Model.Module.TitleElement + " class=\"" + Model.Config.ModuleCssClass +"__title moduletitle\" data-moduleid=\"module" + Model.Module.Id + "\">")
+	@Html.Raw("<" + Model.Module.TitleElement + " class=\"" + Model.Config.SolutionCssClass +"__title moduletitle\" data-moduleid=\"module" + Model.Module.Id + "\">")
 	<text>@Model.Module.Title</text>
 
 	if (Model.Module.IsEditable)


### PR DESCRIPTION
ModuleCssClass will render the whole class for the module, including any user-added classes, which should be on the module wrapper but not on the module title. SolutionCssClass will correctly render the class established by the solution's author.